### PR TITLE
Add support for serverless database model

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -35,6 +35,10 @@
             "type": "string",
             "defaultValue": "Standard"
         },
+        "serverlessAutoPauseDelay": {
+            "type": "int",
+            "defaultValue": 480
+        },
         "logAnalyticsSubscriptionId": {
             "type": "string",
             "defaultValue": "[subscription().subscriptionId]"
@@ -230,6 +234,9 @@
                     },
                     "databaseTier": {
                         "value": "[parameters('databaseTier')]"
+                    },
+                    "serverlessAutoPauseDelay": {
+                        "value": "[parameters('serverlessAutoPauseDelay')]"
                     },
                     "logAnalyticsSubscriptionId": {
                         "value": "[parameters('logAnalyticsSubscriptionId')]"

--- a/azure/template.json
+++ b/azure/template.json
@@ -36,8 +36,8 @@
             "defaultValue": "Standard"
         },
         "serverlessAutoPauseDelay": {
-            "type": "int",
-            "defaultValue": 480
+            "type": "string",
+            "defaultValue": "480"
         },
         "logAnalyticsSubscriptionId": {
             "type": "string",


### PR DESCRIPTION
This PR enables serverless vCore skus for the azure sql database