### PR TITLE
DASD-9882 - Use building block template for data share and role

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -128,8 +128,7 @@
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
         "dataShareName": "[concat(variables('resourceNamePrefix'), '-ds')]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
-        "functionAppName": "[concat(variables('resourceNamePrefix'), '-fa')]",
-        "contentShareName": "[replace(variables('functionAppName'), '-', '')]"
+        "functionAppName": "[concat(variables('resourceNamePrefix'), '-fa')]"
     },
     "resources": [
         {
@@ -350,37 +349,22 @@
             ]
         },
         {
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2021-04-01",
+            "apiVersion": "2020-06-01",
             "name": "[concat(variables('dataShareName'), '-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[variables('resourceGroupName')]",
             "properties": {
                 "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "resources": [
-                        {
-                            "apiVersion": "2020-09-01",
-                            "name": "[variables('dataShareName')]",
-                            "location": "[parameters('resourceGroupLocation')]",
-                            "type": "Microsoft.DataShare/accounts",
-                            "identity": {
-                                "type": "SystemAssigned"
-                            }
-                        }
-                    ],
-                    "outputs": {
-                        "managedServiceIdentityId": {
-                            "type": "string",
-                            "value": "[reference(resourceId(subscription().subscriptionId, variables('resourceGroupName'), 'Microsoft.DataShare/accounts', variables('dataShareName')), '2020-09-01', 'Full').identity.principalId]"
-                        }
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'data-share.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "dataShareName": {
+                        "value": "[variables('dataShareName')]"
                     }
                 }
-            },
-            "dependsOn": [
-                "[concat('storage-account-', parameters('utcValue'))]"
-            ]
+            }
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -459,7 +443,7 @@
                                 },
                                 {
                                     "name": "WEBSITE_CONTENTSHARE",
-                                    "value": "[variables('contentShareName')]"
+                                    "value": "[replace(variables('functionAppName'), '-', '')]"
                                 },
                                 {
                                     "name": "FUNCTIONS_EXTENSION_VERSION",
@@ -506,7 +490,8 @@
                 }
             },
             "dependsOn": [
-                "[concat(variables('appServicePlanName'), '-', parameters('utcValue'))]"
+                "[concat(variables('appServicePlanName'), '-', parameters('utcValue'))]",
+                "[concat(variables('dataShareName'), '-', parameters('utcValue'))]"
             ]
         },
         {
@@ -558,29 +543,29 @@
             ]
         },
         {
-            "type": "Microsoft.Resources/deployments",
             "apiVersion": "2021-04-01",
             "name": "[concat('role-assignment-', variables('dataShareName'), '-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[variables('resourceGroupName')]",
             "properties": {
                 "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "resources": [
-                        {
-                            "type": "Microsoft.DataShare/accounts/providers/roleAssignments",
-                            "apiVersion": "2021-04-01-preview",
-                            "name": "[concat(variables('dataShareName'), '/Microsoft.Authorization/', guid(uniqueString(variables('dataShareName'),'Contributor',reference(concat(variables('functionAppName'), '-', parameters('utcValue'))).outputs.managedServiceIdentityId.value)))]",
-                            "properties": {
-                                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-                                "principalId": "[reference(concat(variables('functionAppName'), '-', parameters('utcValue'))).outputs.managedServiceIdentityId.value]",
-                                "scope": "[resourceId(subscription().subscriptionId, variables('resourceGroupName'), 'Microsoft.DataShare/accounts', variables('dataShareName'))]"
-                            }
-                        }
-                    ]
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'role-assignments/role-assignment-data-share.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "principalId": {
+                        "value": "[reference(concat(variables('functionAppName'), '-', parameters('utcValue'))).outputs.managedServiceIdentityId.value]"
+                    },
+                    "resourceName": {
+                        "value": "[variables('dataShareName')]"
+                    }
                 }
-            }
+            },
+            "dependsOn": [
+                "[concat('storage-account-', parameters('utcValue'))]",
+                "[concat(variables('dataShareName'), '-', parameters('utcValue'))]"
+            ]
         }
     ],
     "outputs": {


### PR DESCRIPTION
### Context

The existing template had issues around using the resourceId as a reference to the Data Share which was deployed as a nested template. 

### Changes proposed in this pull request

- Use the new data share template that outputs the managed identity id and can use the reference function.
- Ue the role assignment template

### Testing 

Test by deploying to AT, TEST and TEST2