### PR TITLE
DASD-9882 - Update default function timer

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -104,7 +104,10 @@
         },
         "functionSchedule": {
             "type": "string",
-            "defaultValue": "0 0 10 * * Thu"
+            "defaultValue": "0 0 0 31 2 0",
+            "metadata": {
+                "description": "defaultValue never runs, override in ADO and set to '0 */30 10-18 * * 4' to check every 30 minutes between 10am and 6pm every Thursday"
+            }
         },
         "dataShareSubscriptionName": {
             "type": "string",


### PR DESCRIPTION
Update the function timer to default to never run. In ADO we can just override the environments we want the function timer to run in.